### PR TITLE
Add PHP 7.4 version test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
     - nightly
 matrix:
     allow_failures:


### PR DESCRIPTION
# Changed log

- Add `php-7.4` version during Travis CI build.