### PR TITLE
Add support for UNICODE-1-1-UTF-7

### DIFF
--- a/src/MbWrapper.php
+++ b/src/MbWrapper.php
@@ -150,6 +150,7 @@ class MbWrapper
         'SHIFTJIS2004' => 'SJIS',
         'SHIFTJIS' => 'SJIS',
         'UJIS' => 'EUC-JP',
+        'UNICODE11UTF7' => 'UTF-7',
         'US' => 'ASCII',
         'USASCII' => 'ASCII',
         'WE8MSWIN1252' => 'WINDOWS-1252',


### PR DESCRIPTION
Hi Zaahid,

I'm seeing some messages come through with the `unicode-1-1-utf-7` charset. For example:

```
Content-Type: text/plain; charset=unicode-1-1-utf-7

This is an automatically generated Delivery Status Notification.

Delivery to the following recipients failed.
```

Probably coming from a very old mail server. However, it was causing the following error in mime-mail-parser which is dependent on this repo.

```
Notice: iconv_strlen(): Wrong charset, conversion from `UNICODE-1-1-UTF-7' to `UCS-4LE' is not allowed
```

Adding this charset as an alias of UTF-7 fixes the issue.