### PR TITLE
Add CESU-8 to UTF-8 mapping

### DIFF
--- a/src/MbWrapper.php
+++ b/src/MbWrapper.php
@@ -44,6 +44,7 @@ class MbWrapper
         'ASMO708' => 'ISO-8859-6',
         'BIG5' => 'BIG-5',
         'BIG5TW' => 'BIG-5',
+        'CESU8' => 'UTF-8',
         'CHINESE' => 'GB18030',
         'CP367' => 'ASCII',
         'CP819' => 'ISO-8859-1',
@@ -189,6 +190,7 @@ class MbWrapper
      */
     public static $iconvAliases = [
         // iconv aliases -- a lot of these may already be supported
+        'CESU8' => 'UTF8',
         'CP154' => 'PT154',
         'CPGR' => 'CP869',
         'CPIS' => 'CP861',


### PR DESCRIPTION
I just received an email (spam) that used CESU-8 to encode the from address and subject. But CESU-8 is not supported by PHP's iconv and threw an ErrorException in my mail application. Since CESU-8 is an alternative to UTF-8, you can simply and safely replace it by UTF-8.