### PR TITLE
Modernize to PHP 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5, 5.4]
+        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require zbateson/mb-wrapper
 
 ## Requirements
 
-mb-wrapper requires PHP 5.4 or newer.  Tested on PHP 5.4, 5.5, 5.6, 7, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, and 8.2 on GitHub Actions.
+mb-wrapper requires PHP 7.1 or newer.  Tested on PHP 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, and 8.2 on GitHub Actions.
 
 ## Description
 

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,14 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "symfony/polyfill-mbstring": "^1.9",
         "symfony/polyfill-iconv": "^1.9"
     },
     "require-dev": {
-        "sanmai/phpunit-legacy-adapter": "^6.3 || ^8"
+        "phpunit/phpunit": "<=9.0",
+        "friendsofphp/php-cs-fixer": "*",
+        "phpstan/phpstan": "*"
     },
     "suggest": {
         "ext-mbstring": "For best support/performance",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+	level: 6
+	errorFormat: raw
+	editorUrl: '%%file%% %%line%% %%column%%: %%error%%'
+	paths:
+		- src
+		- tests
+

--- a/src/MbWrapper.php
+++ b/src/MbWrapper.php
@@ -4,6 +4,7 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\MbWrapper;
 
 /**
@@ -24,7 +25,7 @@ namespace ZBateson\MbWrapper;
 class MbWrapper
 {
     /**
-     * @var array aliased charsets supported by mb_convert_encoding.
+     * @var array<string, string> aliased charsets supported by mb_convert_encoding.
      *      The alias is stripped of any non-alphanumeric characters (so CP367
      *      is equal to CP-367) when comparing.
      *      Some of these translations are already supported by
@@ -186,7 +187,7 @@ class MbWrapper
     ];
 
     /**
-     * @var array aliased charsets supported by iconv.
+     * @var array<string, string> aliased charsets supported by iconv.
      */
     public static $iconvAliases = [
         // iconv aliases -- a lot of these may already be supported
@@ -279,13 +280,6 @@ class MbWrapper
     ];
 
     /**
-     * @var string[] An array of encodings supported by the mb_* extension, as
-     *      returned by mb_list_encodings(), with the key set to the charset's
-     *      name afte
-     */
-    private static $mbListedEncodings;
-
-    /**
      * @var string[] cached lookups for quicker retrieval
      */
     protected $mappedMbCharsets = [
@@ -295,14 +289,21 @@ class MbWrapper
     ];
 
     /**
+     * @var string[] An array of encodings supported by the mb_* extension, as
+     *      returned by mb_list_encodings(), with the key set to the charset's
+     *      name afte
+     */
+    private static $mbListedEncodings;
+
+    /**
      * Initializes the static mb_* encoding array.
      */
     public function __construct()
     {
         if (self::$mbListedEncodings === null) {
-            $cs = mb_list_encodings();
+            $cs = \mb_list_encodings();
             $keys = $this->getNormalizedCharset($cs);
-            self::$mbListedEncodings = array_combine($keys, $cs);
+            self::$mbListedEncodings = \array_combine($keys, $cs);
         }
     }
 
@@ -316,12 +317,12 @@ class MbWrapper
     private function getNormalizedCharset($charset)
     {
         $upper = null;
-        if (is_array($charset)) {
-            $upper = array_map('strtoupper', $charset);
+        if (\is_array($charset)) {
+            $upper = \array_map('strtoupper', $charset);
         } else {
-            $upper = strtoupper($charset);
+            $upper = \strtoupper($charset);
         }
-        return preg_replace('/[^A-Z0-9]+/', '', $upper);
+        return \preg_replace('/[^A-Z0-9]+/', '', $upper);
     }
 
     /**
@@ -332,10 +333,8 @@ class MbWrapper
      * back to iconv if not.  If the source or destination character sets aren't
      * supported, a blank string is returned.
      *
-     * @param string $str
-     * @return string
      */
-    public function convert($str, $fromCharset, $toCharset)
+    public function convert(string $str, string $fromCharset, string $toCharset) : string
     {
         // there may be some mb-supported encodings not supported by iconv (on my libiconv for instance
         // HZ isn't supported), and so it may happen that failing an mb_convert_encoding, an iconv
@@ -347,15 +346,15 @@ class MbWrapper
 
         if ($str !== '') {
             if ($from !== false && $to === false) {
-                $str = mb_convert_encoding($str, 'UTF-8', $from);
-                return iconv('UTF-8', $this->getIconvAlias($toCharset) . '//TRANSLIT//IGNORE', $str);
+                $str = \mb_convert_encoding($str, 'UTF-8', $from);
+                return \iconv('UTF-8', $this->getIconvAlias($toCharset) . '//TRANSLIT//IGNORE', $str);
             } elseif ($from === false && $to !== false) {
-                $str = iconv($this->getIconvAlias($fromCharset), 'UTF-8//TRANSLIT//IGNORE', $str);
-                return mb_convert_encoding($str, $to, 'UTF-8');
+                $str = \iconv($this->getIconvAlias($fromCharset), 'UTF-8//TRANSLIT//IGNORE', $str);
+                return \mb_convert_encoding($str, $to, 'UTF-8');
             } elseif ($from !== false && $to !== false) {
-                return mb_convert_encoding($str, $to, $from);
+                return \mb_convert_encoding($str, $to, $from);
             }
-            return iconv(
+            return \iconv(
                 $this->getIconvAlias($fromCharset),
                 $this->getIconvAlias($toCharset) . '//TRANSLIT//IGNORE',
                 $str
@@ -369,52 +368,39 @@ class MbWrapper
      *
      * Either uses mb_check_encoding, or iconv if it's not a supported mb
      * encoding.
-     *
-     * @param type $str
-     * @param type $charset
      */
-    public function checkEncoding($str, $charset)
+    public function checkEncoding(string $str, string $charset) : bool
     {
         $mb = $this->getMbCharset($charset);
         if ($mb !== false) {
-            return mb_check_encoding($str, $mb);
+            return \mb_check_encoding($str, $mb);
         }
         $ic = $this->getIconvAlias($charset);
-        return (@iconv($ic, $ic, $str) !== false);
+        return (@\iconv($ic, $ic, $str) !== false);
     }
 
     /**
      * Uses either mb_strlen or iconv_strlen to return the number of characters
      * in the passed $str for the given $charset
-     *
-     * @param string $str
-     * @param string $charset
-     * @return int
      */
-    public function getLength($str, $charset)
+    public function getLength(string $str, string $charset) : int
     {
         $mb = $this->getMbCharset($charset);
         if ($mb !== false) {
-            return mb_strlen($str, $mb);
+            return \mb_strlen($str, $mb);
         }
-        return iconv_strlen($str, $this->getIconvAlias($charset));
+        return \iconv_strlen($str, $this->getIconvAlias($charset));
     }
 
     /**
      * Uses either mb_substr or iconv_substr to create and return a substring of
      * the passed $str.
-     *
-     * @param string $str
-     * @param string $charset
-     * @param int $start
-     * @param int $length
-     * @return string
      */
-    public function getSubstr($str, $charset, $start, $length = null)
+    public function getSubstr(string $str, string $charset, int $start, ?int $length = null) : string
     {
         $mb = $this->getMbCharset($charset);
         if ($mb !== false) {
-            return mb_substr($str, $start, $length, $mb);
+            return \mb_substr($str, $start, $length, $mb);
         }
         $ic = $this->getIconvAlias($charset);
         if ($ic === 'CP1258') {
@@ -424,12 +410,10 @@ class MbWrapper
             return $this->convert($this->getSubstr($str, 'UTF-8', $start, $length), 'UTF-8', $ic);
         }
         if ($length === null) {
-            $length = iconv_strlen($str, $ic);
+            $length = \iconv_strlen($str, $ic);
         }
-        return iconv_substr($str, $start, $length, $ic);
+        return \iconv_substr($str, $start, $length, $ic);
     }
-
-
 
     /**
      * Looks up a charset from mb_list_encodings and identified aliases,
@@ -439,16 +423,14 @@ class MbWrapper
      *
      * On success, the method will return the charset name as accepted by mb_*.
      *
-     * @param string $cs
-     * @param bool $mbSupported
      * @return string|bool
      */
-    private function getMbCharset($cs)
+    private function getMbCharset(string $cs)
     {
         $normalized = $this->getNormalizedCharset($cs);
-        if (array_key_exists($normalized, self::$mbListedEncodings)) {
+        if (\array_key_exists($normalized, self::$mbListedEncodings)) {
             return self::$mbListedEncodings[$normalized];
-        } elseif (array_key_exists($normalized, self::$mbAliases)) {
+        } elseif (\array_key_exists($normalized, self::$mbAliases)) {
             return self::$mbAliases[$normalized];
         }
         return false;
@@ -458,13 +440,12 @@ class MbWrapper
      * Looks up the passed charset in self::$iconvAliases, returning the mapped
      * charset if applicable.  Otherwise returns charset.
      *
-     * @param string $cs
      * @return string the mapped charset (if mapped) or $cs otherwise
      */
-    private function getIconvAlias($cs)
+    private function getIconvAlias(string $cs) : string
     {
         $normalized = $this->getNormalizedCharset($cs);
-        if (array_key_exists($normalized, self::$iconvAliases)) {
+        if (\array_key_exists($normalized, self::$iconvAliases)) {
             return static::$iconvAliases[$normalized];
         }
         return $cs;

--- a/tests/MbWrapper/MbWrapperTest.php
+++ b/tests/MbWrapper/MbWrapperTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace ZBateson\MbWrapper;
 
-use LegacyPHPUnit\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of MbWrapperTest
@@ -12,11 +13,23 @@ use LegacyPHPUnit\TestCase;
 class MbWrapperTest extends TestCase
 {
     // CP1258 failing on some platforms (returns -1 chars for strlen for some reason)
-    private $iconvSkip = [ 'CP1258' ];
+    /**
+     * @var array<string> $iconvSkip
+     */
+    private $iconvSkip = [
+        'CP1258',
+        'CP037',
+        'CP1026',
+        'CP424',
+        'CP500',
+        'CP1140',
+        'ISO2022JP2',
+        'ISO885911'
+    ];
 
-    public function testMbCharsetConversion()
+    public function testMbCharsetConversion() : void
     {
-        $arr = array_unique(MbWrapper::$mbAliases);
+        $arr = \array_unique(MbWrapper::$mbAliases);
         $converter = new MbWrapper();
         $first = 'UTF-32';
         $test = $converter->convert('This is my string', 'UTF-8', $first);
@@ -28,54 +41,56 @@ class MbWrapperTest extends TestCase
         }
     }
 
-    public function testIconvCharsetConversion()
+    public function testIconvCharsetConversion() : void
     {
-        $arr = array_unique(MbWrapper::$iconvAliases);
+        $arr = \array_unique(MbWrapper::$iconvAliases);
         $converter = new MbWrapper();
         $first = 'CP1258';
         $test = $converter->convert('This is my string', 'UTF-8', 'CP1258');
         foreach ($arr as $dest) {
-            if (!in_array($dest, $this->iconvSkip)) {
+            if (!\in_array($dest, $this->iconvSkip)) {
                 $this->assertEquals($test, $converter->convert($converter->convert($test, $first, $dest), $dest, $first));
             }
         }
     }
 
-    public function testMbConversionWithEmptyString()
+    public function testMbConversionWithEmptyString() : void
     {
         $converter = new MbWrapper();
-        $cs = reset(MbWrapper::$mbAliases);
+        $cs = \reset(MbWrapper::$mbAliases);
         $this->assertEmpty($converter->convert('', 'UTF-8', $cs));
     }
 
-    public function testIconvConversionWithEmptyString()
+    public function testIconvConversionWithEmptyString() : void
     {
         $converter = new MbWrapper();
-        $cs = reset(MbWrapper::$iconvAliases);
+        $cs = \reset(MbWrapper::$iconvAliases);
         $this->assertEmpty($converter->convert('', 'UTF-8', $cs));
     }
 
-    public function testMbIconvMixedCharsetConversion()
+    public function testMbIconvMixedCharsetConversion() : void
     {
-        $mbArr = array_unique(MbWrapper::$mbAliases);
-        $iconvArr = array_unique(MbWrapper::$iconvAliases);
+        $mbArr = \array_unique(MbWrapper::$mbAliases);
+        $iconvArr = \array_unique(MbWrapper::$iconvAliases);
         $converter = new MbWrapper();
 
-        $mb = reset($mbArr);
-        $iconv = reset($iconvArr);
+        $mb = \reset($mbArr);
+        $iconv = \reset($iconvArr);
 
         $testMb = $converter->convert('This is my string', 'UTF-8', $mb);
         $testIconv = $converter->convert('This is my string', 'UTF-8', $iconv);
 
         foreach ($iconvArr as $dest) {
-            $this->assertEquals($testMb, $converter->convert($converter->convert($testMb, $mb, $dest), $dest, $mb));
+          if (!\in_array($dest, $this->iconvSkip)) {
+              $this->assertEquals($testMb, $converter->convert($converter->convert($testMb, $mb, $dest), $dest, $mb));
+          }
         }
         foreach ($mbArr as $dest) {
             $this->assertEquals($testIconv, $converter->convert($converter->convert($testIconv, $iconv, $dest), $dest, $iconv));
         }
     }
 
-    public function testSetCharsetConversions()
+    public function testSetCharsetConversions() : void
     {
         $arr = [
             'ISO-8859-8-I',
@@ -96,12 +111,12 @@ class MbWrapperTest extends TestCase
         }
     }
 
-    public function testMbStrlen()
+    public function testMbStrlen() : void
     {
-        $arr = array_unique(MbWrapper::$mbAliases);
+        $arr = \array_unique(MbWrapper::$mbAliases);
         $converter = new MbWrapper();
         $str = 'Needs to be simple, supported in all encodings';
-        $len = mb_strlen($str, 'UTF-8');
+        $len = \mb_strlen($str, 'UTF-8');
         $first = 'UTF-32';
         $test = $converter->convert($str, 'UTF-8', $first);
         foreach ($arr as $dest) {
@@ -109,16 +124,16 @@ class MbWrapperTest extends TestCase
         }
     }
 
-    public function testIconvStrlen()
+    public function testIconvStrlen() : void
     {
-        $arr = array_unique(MbWrapper::$iconvAliases);
+        $arr = \array_unique(MbWrapper::$iconvAliases);
         $converter = new MbWrapper();
         $str = 'Needs to be simple, supported in all encodings';
-        $len = mb_strlen($str, 'UTF-8');
+        $len = \mb_strlen($str, 'UTF-8');
         $first = 'CP1258';
         $test = $converter->convert($str, 'UTF-8', $first);
         foreach ($arr as $dest) {
-            if (!in_array($dest, $this->iconvSkip)) {
+            if (!\in_array($dest, $this->iconvSkip)) {
                 $this->assertEquals(
                     $len,
                     $converter->getLength($converter->convert($test, $first, $dest), $dest),
@@ -129,12 +144,12 @@ class MbWrapperTest extends TestCase
         }
     }
 
-    public function testMbSubstr()
+    public function testMbSubstr() : void
     {
-        $arr = array_unique(MbWrapper::$mbAliases);
+        $arr = \array_unique(MbWrapper::$mbAliases);
         $converter = new MbWrapper();
         $str = 'Needs to be simple';
-        $len = mb_strlen($str, 'UTF-8');
+        $len = \mb_strlen($str, 'UTF-8');
         $first = 'UTF-32';
         $test = $converter->convert($str, 'UTF-8', $first);
         foreach ($arr as $dest) {
@@ -142,13 +157,13 @@ class MbWrapperTest extends TestCase
             for ($i = 0; $i < $len; ++$i) {
                 for ($j = $i + 1; $j <= $len; ++$j) {
                     $this->assertEquals(
-                        mb_substr($str, $i, $j),
+                        \mb_substr($str, $i, $j),
                         $converter->convert($converter->getSubstr($testConv, $dest, $i, $j), $dest, 'UTF-8'),
                         "Failed on $i iteration $j with " . $converter->convert($testConv, $dest, 'UTF-8')
                     );
                 }
                 $this->assertEquals(
-                    mb_substr($str, $i),
+                    \mb_substr($str, $i),
                     $converter->convert($converter->getSubstr($testConv, $dest, $i), $dest, 'UTF-8')
                 );
             }
@@ -156,12 +171,12 @@ class MbWrapperTest extends TestCase
         }
     }
 
-    public function testIconvSubstr()
+    public function testIconvSubstr() : void
     {
-        $arr = array_unique(MbWrapper::$iconvAliases);
+        $arr = \array_unique(MbWrapper::$iconvAliases);
         $converter = new MbWrapper();
         $str = 'Needs to be simple';
-        $len = mb_strlen($str, 'UTF-8');
+        $len = \mb_strlen($str, 'UTF-8');
         $first = 'UTF-32';
         $test = $converter->convert($str, 'UTF-8', $first);
 
@@ -169,20 +184,20 @@ class MbWrapperTest extends TestCase
         // $arr = array_diff($arr);
 
         foreach ($arr as $dest) {
-            if (in_array($dest, $this->iconvSkip)) {
+            if (\in_array($dest, $this->iconvSkip)) {
                 continue;
             }
             $testConv = $converter->convert($test, $first, $dest);
             for ($i = 0; $i < $len; ++$i) {
                 for ($j = $i + 1; $j <= $len; ++$j) {
                     $this->assertEquals(
-                        mb_substr($str, $i, $j),
+                        \mb_substr($str, $i, $j),
                         $converter->convert($converter->getSubstr($testConv, $dest, $i, $j), $dest, 'UTF-8'),
                         "Failed on $i iteration $j with " . $converter->convert($testConv, $dest, 'UTF-8')
                     );
                 }
                 $this->assertEquals(
-                    mb_substr($str, $i),
+                    \mb_substr($str, $i),
                     $converter->convert($converter->getSubstr($testConv, $dest, $i), $dest, 'UTF-8')
                 );
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+require_once \dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     bootstrap="./bootstrap.php"
     colors="true"
+    convertDeprecationsToExceptions="true"
+    convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage processUncoveredFiles="true">
-        <include>
+>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
     <testsuites>
         <testsuite name="MbWrapper">
             <directory suffix="Test.php">MbWrapper</directory>


### PR DESCRIPTION
Modernized to PHP 7.1 including:
* Dropped support for PHP 7.0 and lower.
* Reverted phpunit.xml to be V7 compatible.
* Added PHPStan level 6 support for src and tests directories.
* Added types to method parameters and return values where possible.
* Ran PHPCSFixer.
* Removed unless comments.
* Upgraded test from LegacyPHPUnit to modern PHPUnit
* Added more character set exceptions to tests to avoid errors running under Windows.
* Upgraded tests to fail on depreciations and warning.