### PR TITLE
Use explicit nullable type for PHP 8.4

### DIFF
--- a/src/MbWrapper.php
+++ b/src/MbWrapper.php
@@ -342,7 +342,7 @@ class MbWrapper
         return $ret;
     }
     
-    private function iconvSubstr(string $str, string $charset, int $start, int $length = null) : string
+    private function iconvSubstr(string $str, string $charset, int $start, ?int $length = null) : string
     {
         $ret = @\iconv_substr($str, $start, $length, $charset . '//TRANSLIT//IGNORE');
         if ($ret === false) {


### PR DESCRIPTION
Implicitly marking parameter $length as nullable is deprecated, the explicit nullable type must be used instead